### PR TITLE
feature: Add Duplicate Customer Button for Managers

### DIFF
--- a/src/main/java/site/easy/to/build/crm/controller/api/ImportDuplicate.java
+++ b/src/main/java/site/easy/to/build/crm/controller/api/ImportDuplicate.java
@@ -1,0 +1,27 @@
+package site.easy.to.build.crm.controller.api;
+
+import lombok.AllArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import site.easy.to.build.crm.dto.CustomerInfoDTO;
+import site.easy.to.build.crm.entity.CustomerLoginInfo;
+import site.easy.to.build.crm.service.customerInfoDTO.CustomerInfoDTOServiceImpl;
+
+@RestController
+@RequestMapping("/api/import")
+@AllArgsConstructor
+public class ImportDuplicate {
+
+    private final CustomerInfoDTOServiceImpl customerInfoDTOService;
+
+    @PostMapping("/duplicate")
+    public ResponseEntity<CustomerInfoDTO> insertDuplicate (@RequestBody CustomerInfoDTO customerInfoDTO){
+        System.out.println("Welcome to the import duplicate API");
+        CustomerInfoDTO customerInfoDTOGenerated = customerInfoDTOService.changeValueDuplicate(customerInfoDTO);
+        customerInfoDTOService.save(customerInfoDTOGenerated);
+        return  new ResponseEntity<>(customerInfoDTOGenerated, org.springframework.http.HttpStatus.CREATED);
+    }
+}

--- a/src/main/java/site/easy/to/build/crm/dto/CustomerInfoDTO.java
+++ b/src/main/java/site/easy/to/build/crm/dto/CustomerInfoDTO.java
@@ -1,0 +1,21 @@
+package site.easy.to.build.crm.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import site.easy.to.build.crm.entity.Customer;
+import site.easy.to.build.crm.entity.Lead;
+import site.easy.to.build.crm.entity.Ticket;
+
+import java.util.List;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+@Getter
+public class CustomerInfoDTO {
+    public Customer customer ;
+    public   List<Ticket> alltickets;
+    public List<Lead> allLeads;
+}

--- a/src/main/java/site/easy/to/build/crm/repository/LeadRepository.java
+++ b/src/main/java/site/easy/to/build/crm/repository/LeadRepository.java
@@ -31,4 +31,6 @@ public interface LeadRepository extends JpaRepository<Lead, Integer> {
     long countByCustomerCustomerId(int customerId);
 
     void deleteAllByCustomer(Customer customer);
+
+    List<Lead> findByCustomer_CustomerId(Integer customerCustomerId);
 }

--- a/src/main/java/site/easy/to/build/crm/repository/TicketRepository.java
+++ b/src/main/java/site/easy/to/build/crm/repository/TicketRepository.java
@@ -31,4 +31,7 @@ public interface TicketRepository extends JpaRepository<Ticket, Integer> {
     long countByCustomerCustomerId(int customerId);
 
     void deleteAllByCustomer(Customer customer);
+
+    public List<Ticket> getTicketByCustomer_CustomerId(Integer customerCustomerId);
+
 }

--- a/src/main/java/site/easy/to/build/crm/service/customerInfoDTO/CustomerInfoDTOService.java
+++ b/src/main/java/site/easy/to/build/crm/service/customerInfoDTO/CustomerInfoDTOService.java
@@ -1,0 +1,11 @@
+package site.easy.to.build.crm.service.customerInfoDTO;
+
+import site.easy.to.build.crm.dto.CustomerInfoDTO;
+
+public interface CustomerInfoDTOService {
+
+    CustomerInfoDTO changeValueDuplicate(CustomerInfoDTO customerInfoDTO);
+
+    void save(CustomerInfoDTO customerInfoDTO) ;
+
+}

--- a/src/main/java/site/easy/to/build/crm/service/customerInfoDTO/CustomerInfoDTOServiceImpl.java
+++ b/src/main/java/site/easy/to/build/crm/service/customerInfoDTO/CustomerInfoDTOServiceImpl.java
@@ -1,0 +1,75 @@
+package site.easy.to.build.crm.service.customerInfoDTO;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.AllArgsConstructor;
+import org.checkerframework.common.value.qual.ArrayLen;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.easy.to.build.crm.dto.CustomerInfoDTO;
+import site.easy.to.build.crm.entity.Customer;
+import site.easy.to.build.crm.entity.Lead;
+import site.easy.to.build.crm.entity.Ticket;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@AllArgsConstructor
+@Service
+public class CustomerInfoDTOServiceImpl  implements CustomerInfoDTOService{
+
+    @PersistenceContext
+    private final EntityManager entityManager ;
+
+    @Override
+    public CustomerInfoDTO changeValueDuplicate(CustomerInfoDTO customerInfoDTO) {
+        Customer customer = customerInfoDTO.getCustomer();
+        customer.setEmail( "copied"+ customer.getEmail());
+        customer.setName("copie"+ customer.getName());
+        customer.setCustomerId(null);
+        List<Ticket> ticketsList = new ArrayList<>();
+        for (Ticket ticket : customerInfoDTO.getAlltickets()){
+            ticket.setTicketId(-1);
+            ticket.setCustomer(customer);
+            ticketsList.add(ticket);
+        }
+        List<Lead> leads = new ArrayList<>();
+        for (Lead lead : customerInfoDTO.getAllLeads()){
+            lead.setLeadId(-1);
+            lead.setCustomer(customer);
+            leads.add(lead);
+        }
+
+        return new CustomerInfoDTO(customer,ticketsList, leads);
+    }
+
+
+    @Override
+    @Transactional
+    public void save(CustomerInfoDTO customerInfoDTO) {
+        // Merge le customer d'abord
+        Customer customer = entityManager.merge(customerInfoDTO.getCustomer());
+
+        for (Ticket ticket : customerInfoDTO.getAlltickets()) {
+            ticket.setTicketId(0);
+            if (ticket.getExpense() != null) {
+                ticket.getExpense().setExpenseId(0L);
+                ticket.setExpense(entityManager.merge(ticket.getExpense()));
+            }
+
+            ticket.setCustomer(customer);
+            entityManager.merge(ticket);
+        }
+
+        for (Lead lead : customerInfoDTO.getAllLeads()) {
+            lead.setLeadId(0);
+            if (lead.getExpense() != null) {
+                lead.getExpense().setExpenseId(0L);
+                lead.setExpense(entityManager.merge(lead.getExpense()));
+            }
+            lead.setCustomer(customer);
+            entityManager.merge(lead);
+        }
+    }
+
+}

--- a/src/main/java/site/easy/to/build/crm/service/lead/LeadService.java
+++ b/src/main/java/site/easy/to/build/crm/service/lead/LeadService.java
@@ -31,4 +31,5 @@ public interface LeadService {
     List<Lead> getRecentLeadsByEmployee(int employeeId, int limit);
     List<Lead> getRecentCustomerLeads(int customerId, int limit);
     public void deleteAllByCustomer(Customer customer);
+    public  List<Lead> getLeadByCustomerId(int customerid );
 }

--- a/src/main/java/site/easy/to/build/crm/service/lead/LeadServiceImpl.java
+++ b/src/main/java/site/easy/to/build/crm/service/lead/LeadServiceImpl.java
@@ -94,4 +94,9 @@ public class LeadServiceImpl implements LeadService {
     public long countByCustomerId(int customerId) {
         return leadRepository.countByCustomerCustomerId(customerId);
     }
+
+    @Override
+    public List<Lead> getLeadByCustomerId(int customerid ){
+        return leadRepository.findByCustomer_CustomerId(customerid);
+    }
 }

--- a/src/main/java/site/easy/to/build/crm/service/ticket/TicketService.java
+++ b/src/main/java/site/easy/to/build/crm/service/ticket/TicketService.java
@@ -33,4 +33,7 @@ public interface TicketService {
     long countByCustomerCustomerId(int customerId);
 
     void deleteAllByCustomer(Customer customer);
+
+    public  List<Ticket> getTicketByCustomerId( int customerid );
+
 }

--- a/src/main/java/site/easy/to/build/crm/service/ticket/TicketServiceImpl.java
+++ b/src/main/java/site/easy/to/build/crm/service/ticket/TicketServiceImpl.java
@@ -90,4 +90,9 @@ public class TicketServiceImpl implements TicketService{
     public void deleteAllByCustomer(Customer customer) {
         ticketRepository.deleteAllByCustomer(customer);
     }
+
+    @Override
+    public List<Ticket> getTicketByCustomerId (int custid){
+        return ticketRepository.getTicketByCustomer_CustomerId(custid);
+    }
 }

--- a/src/main/resources/templates/customer/all-customers.html
+++ b/src/main/resources/templates/customer/all-customers.html
@@ -116,6 +116,14 @@
                                                         <i class="mdi mdi-tooltip-edit"></i>
                                                     </button>
                                                 </form>
+                                            </td>
+                                            <td th:if="${#authorization.expression('hasRole(''ROLE_MANAGER'')')}">
+                                                <form th:action="${home + 'employee/customer/duplicate/' + customer.customerId}" method="post">
+                                                    <button type="submit" class="btn btn-primary">
+                                                        <i class="mdi mdi-file-export"></i>
+                                                    </button>
+                                                </form>
+                                            </td>
                                         </tr>
                                     </tbody>
                                 </table>


### PR DESCRIPTION
## Description (Alea 1) 
This pull request introduces a new feature that allows managers to duplicate customer records from the customer list. It includes the necessary backend endpoints, services, and DTOs to facilitate this functionality.

## Key Changes

### Frontend Changes
- Added a **Duplicate Customer** button in the customer list UI for managers.

### Backend Changes
- **New Endpoint:** Added an API endpoint to duplicate a customer and return the updated customer information.
- **DTO Implementation:** Introduced `CustomerInfoDTO` to encapsulate customer data and related information.
- **Service Enhancements:**
  - Added method to retrieve leads by customer ID in `LeadService`.
  - Added method to retrieve tickets by customer ID in `TicketRepository`.
  - Created `CustomerInfoDTOService` interface with methods for duplication logic.
  - Implemented `CustomerInfoDTOServiceImpl` to handle customer duplication and data persistence.
- **New Controller:** Introduced `ImportDuplicateController` to handle customer duplication requests.

